### PR TITLE
Generate atom feeds for blog posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# VIM
+# =========
+# swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags

--- a/configs/atom.ini
+++ b/configs/atom.ini
@@ -1,0 +1,3 @@
+[blog]
+name = PythonExpress Blog
+source_path = /posts

--- a/delta.lektorproject
+++ b/delta.lektorproject
@@ -1,5 +1,9 @@
 [project]
 name = delta
+url = http://blog.pythonexpress.in/
 
 [servers.ghpages]
 target = ghpages+https://pythonindia/wye-blog?cname=blog.pythonexpress.in
+
+[packages]
+lektor-atom = 0.2

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -76,6 +76,14 @@
                         </span>
                     </a>
                 </li>
+                <li>
+                    <a href="{{ 'posts@atom/blog'|url }}">
+                        <span class="fa-stack fa-lg">
+                            <i class="fa fa-circle fa-stack-2x"></i>
+                            <i class="fa fa-rss fa-stack-1x fa-inverse"></i>
+                        </span>
+                    </a>
+                </li>
             </ul>
             <p class="">Copyright &copy; Python Express</p>
         </div>


### PR DESCRIPTION
* **Description:** RSS feed is important for engaging readers. It will help them to read latest blog posts published by the project. I found this blog was missing that feature. Adding feature which will generate RSS feeds.

* **Libraries:** Using plugin [lektor-atom](https://github.com/ajdavis/lektor-atom) for this feature.